### PR TITLE
Replace obsolete CS with Serbia (RS) and add Montenegro (ME)

### DIFF
--- a/src/app/assets/countries.json
+++ b/src/app/assets/countries.json
@@ -906,6 +906,12 @@
     "emoji": "🇲🇳"
   },
   {
+    "isoCode": "ME",
+    "name": "Montenegro",
+    "countryCode": "382",
+    "emoji": "🇲🇪"
+  },
+  {
     "isoCode": "MS",
     "name": "Montserrat",
     "countryCode": "1",
@@ -1181,9 +1187,10 @@
     "emoji": "🇸🇳"
   },
   {
-    "isoCode": "CS",
-    "name": "Serbia and Montenegro",
-    "countryCode": ""
+    "isoCode": "RS",
+    "name": "Serbia",
+    "countryCode": "381",
+    "emoji": "🇷🇸"
   },
   {
     "isoCode": "SC",


### PR DESCRIPTION
## Summary

The dataset only listed the obsolete `CS / "Serbia and Montenegro"` entry (dissolved in 2006, no dial code). Replace it with the two modern successor countries:

- **Serbia** — ISO `RS`, dial code `+381`
- **Montenegro** — ISO `ME`, dial code `+382`

This was reported via the Uplift app's Organization Settings phone-number country picker — Serbia couldn't be selected even though `libphonenumber-js` already knows about +381.

## Changes

`src/app/assets/countries.json`:
- Replace the `CS` "Serbia and Montenegro" entry with a modern `RS` Serbia entry.
- Insert Montenegro (`ME`, +382) alphabetically between Mongolia and Montserrat.

## Test plan

- [ ] JSON parses and total count is 240 (was 239 with obsolete CS; net +1 since CS was replaced and ME added).
- [ ] `RS` appears alphabetically in the S section (between Senegal and Seychelles).
- [ ] `ME` appears alphabetically in the M section (between Mongolia and Montserrat).
- [ ] No remaining `CS` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)